### PR TITLE
Fix type error when electricity_collection is null

### DIFF
--- a/src/Model/Invoice/RegionalInformation.php
+++ b/src/Model/Invoice/RegionalInformation.php
@@ -537,7 +537,7 @@ class RegionalInformation implements CreatableFromArray
         $regionalInfo->efakturaRecipientBankCode = $data['efaktura_recipient_bank_code'] ?? null;
         $regionalInfo->rotavdragPersonalNumber = $data['efaktura_recipient_id_number'] ?? null;
         $regionalInfo->efakturaRequestedAmount = $data['efaktura_requested_amount'] ?? null;
-        $regionalInfo->collectionForElectricityInvoices = CollectionForElectricityInvoices::createFromArray($data['electricity_collection']);
+        $regionalInfo->collectionForElectricityInvoices = CollectionForElectricityInvoices::createFromArray($data['electricity_collection'] ?? []);
 
         return $regionalInfo;
     }


### PR DESCRIPTION
Billogram recently updated the api in a silent upgrade. The `electricity_collection` can now return null which made the `CollectionForElectricityInvoices::createFromArray` crash. This commit is not a complete fix but solves the current crash caused by Billogram returning null values.

According to the Billogram documentation `electricity_collection` is deprecated and should no longer be defined at the billogram level, but instead defined at item level.